### PR TITLE
ChecklistPrevent GUI NRE spam in MinimalHelpOverlay. Done.Remove Shad…

### DIFF
--- a/unity_project/Assets/Scripts/Presentation/AutoBootstrap.cs
+++ b/unity_project/Assets/Scripts/Presentation/AutoBootstrap.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+
+namespace FrontierAges.Presentation {
+    public static class AutoBootstrap {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void EnsurePlayableScene(){
+            Debug.Log("[AutoBootstrap] Ensuring playable scene (camera/ground/selection/help/simbootstrap)");
+            // Ensure SimBootstrap exists
+            var boot = Object.FindFirstObjectByType<SimBootstrap>();
+            if (boot == null) {
+                var go = new GameObject("SimBootstrap");
+                boot = go.AddComponent<SimBootstrap>();
+            }
+
+            // Camera: ensure and configure a top-down view
+            var cam = Camera.main;
+            if (cam == null) {
+                var camGo = new GameObject("Main Camera");
+                cam = camGo.AddComponent<Camera>();
+                camGo.tag = "MainCamera";
+                camGo.AddComponent<AudioListener>();
+            }
+            if (cam != null) {
+                cam.transform.position = new Vector3(20f, 30f, -20f);
+                cam.transform.rotation = Quaternion.Euler(60f, 45f, 0f);
+                cam.orthographic = false;
+                cam.clearFlags = CameraClearFlags.SolidColor;
+                cam.backgroundColor = new Color(0.16f, 0.17f, 0.20f, 1f);
+            }
+
+            // Ground: ensure we have a plane named 'Ground' to click on
+            var existingGround = GameObject.Find("Ground");
+            if (existingGround == null) {
+                var ground = GameObject.CreatePrimitive(PrimitiveType.Plane);
+                ground.name = "Ground";
+                ground.transform.position = Vector3.zero;
+                ground.transform.localScale = new Vector3(10f, 1f, 10f);
+                var r = ground.GetComponent<Renderer>();
+                if (r != null) {
+                    try { var mat = r.material; if (mat != null) mat.color = new Color(0.22f, 0.24f, 0.26f, 1f); } catch {}
+                }
+            }
+
+            // Ensure selection and help overlay exist
+            if (Object.FindFirstObjectByType<SelectionManager>() == null) {
+                var sel = new GameObject("SelectionManager");
+                sel.AddComponent<SelectionManager>();
+            }
+            if (Object.FindFirstObjectByType<MinimalHelpOverlay>() == null) {
+                var help = new GameObject("HelpOverlay");
+                help.AddComponent<MinimalHelpOverlay>();
+            }
+
+            // Drop a short-lived visible marker at origin to confirm runtime init
+            var marker = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            marker.name = "BootstrapMarker";
+            marker.transform.position = new Vector3(0f, 0.5f, 0f);
+            marker.transform.localScale = new Vector3(0.5f, 1f, 0.5f);
+            var mr = marker.GetComponent<Renderer>();
+            if (mr != null) {
+                try { var m = mr.material; if (m != null) m.color = new Color(1f, 0f, 1f, 1f); } catch {}
+            }
+            Object.Destroy(marker, 5f);
+        }
+    }
+}

--- a/unity_project/Assets/Scripts/Presentation/AutoBootstrap.cs.meta
+++ b/unity_project/Assets/Scripts/Presentation/AutoBootstrap.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cbfe4128da3d61047a677c8df17f0b02

--- a/unity_project/Assets/Scripts/Presentation/MinimalHelpOverlay.cs
+++ b/unity_project/Assets/Scripts/Presentation/MinimalHelpOverlay.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+using FrontierAges.Sim;
+
+namespace FrontierAges.Presentation {
+    // Lightweight, zero-setup overlay for help + key sim stats. Safe for auto-injected bootstrap.
+    public class MinimalHelpOverlay : MonoBehaviour {
+        private Simulator _sim;
+        private bool _visible = true; // toggle with F1
+    private GUIStyle _mono;
+    private GUIStyle _monoSmall;
+
+        void Start(){ var boot = FindFirstObjectByType<SimBootstrap>(); _sim = boot?.GetSimulator(); }
+
+        private void EnsureStyles(){
+            if (_mono != null && _monoSmall != null) return;
+            try {
+                // Be extremely defensive: GUI.skin can be null early/late in player lifecycle.
+                var baseLabel = (GUI.skin != null && GUI.skin.label != null) ? GUI.skin.label : new GUIStyle();
+                _mono = new GUIStyle(baseLabel){ fontSize = 14, richText = false, alignment = TextAnchor.UpperLeft };
+                _monoSmall = new GUIStyle(baseLabel){ fontSize = 12, richText = false, alignment = TextAnchor.UpperLeft };
+                if (_mono == null) _mono = GUIStyle.none; // ultimate fallback to avoid NRE
+                if (_monoSmall == null) _monoSmall = GUIStyle.none;
+            } catch {
+                // If anything fails, fall back to safe styles and let OnGUI proceed.
+                _mono ??= GUIStyle.none;
+                _monoSmall ??= GUIStyle.none;
+            }
+        }
+
+        void Update(){ if (Input.GetKeyDown(KeyCode.F1)) _visible = !_visible; }
+
+        void OnGUI(){
+            // Skip if GUI system isn't processing a valid event yet.
+            if (!_visible) return;
+            if (Event.current == null) return;
+            EnsureStyles();
+            float pad = 8f;
+            // Help (left)
+            string help =
+                "F1: Toggle Help\n"+
+                "RMB: Move selected\n"+
+                "LMB: Select / Drag to box\n"+
+                "B: Build mode, ,/. cycle type\n"+
+                "T: Train unit (first bldg)\n"+
+                "Y: Queue 3x train\n"+
+                "P: Set rally at mouse, O: Clear\n"+
+                "C/V: Cancel prod (head/tail)\n"+
+                "G: Gather (workers)\n"+
+                "H: Toggle auto-assign workers\n"+
+                "A: Attack target  |  Shift+A: Attack-move\n"+
+                "F5: Save snapshot  |  F9: Load snapshot\n"+
+                "R: Start research (test)";
+            try {
+                GUI.Label(new Rect(pad, pad, 420, 280), help ?? string.Empty, _mono ?? GUIStyle.none);
+            } catch { enabled = false; return; }
+
+            // Stats (right)
+            if(_sim!=null){
+                var f = _sim.State.Factions[0];
+                string stats = $"Tick: {_sim.State.Tick}\n"+
+                               $"Hash: {_sim.LastTickHash:X16}\n"+
+                               $"Avg μs: {_sim.State.AvgTickDurationMicro}\n\n"+
+                               $"Food: {f.Food}  Wood: {f.Wood}\n"+
+                               $"Stone: {f.Stone}  Metal: {f.Metal}\n"+
+                               $"Pop: {f.Pop}/{f.PopCap}\n"+
+                               $"Units: {_sim.State.UnitCount}  Buildings: {_sim.State.BuildingCount}";
+                var w = 320f; var h = 160f; var x = Screen.width - w - pad; var y = pad;
+                try {
+                    GUI.Box(new Rect(x-4, y-4, w+8, h+8), GUIContent.none);
+                    GUI.Label(new Rect(x, y, w, h), stats ?? string.Empty, _monoSmall ?? GUIStyle.none);
+                } catch { enabled = false; return; }
+            }
+        }
+    }
+}

--- a/unity_project/Assets/Scripts/Presentation/MinimalHelpOverlay.cs.meta
+++ b/unity_project/Assets/Scripts/Presentation/MinimalHelpOverlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a0f7a0d4a8f4c45a9c1e1a1e9f7b321
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
…er.Find usage that caused magenta. Done.Ensure StreamingAssets/data is present in the built player. Done.Force a solid camera background (no magenta if skybox missing). Done.Rebuild and rerun, then confirm units/resources spawn and data loaded. Pending.What I changedMinimalHelpOverlay.csDefensive OnGUI: guards Event.current, robust style creation, try/catch. Prevents the GUI Label NRE loop.SimBootstrap.csRewrote default prefab creators to only recolor renderer.material instead of creating materials with Shader.Find. The ghost tries transparency only if supported; no hard shader dependency.AutoBootstrap.csGround plane and marker now recolor existing materials, no Shader.Find.Camera now clears to a neutral solid color (dark grey) instead of skybox, so no full-screen magenta.build-and-run.ps1After mirroring build to bin/windows-x64-latest, it now ensures FrontierAges_Data/StreamingAssets/data exists by copying repo-level data/* into the player.StandaloneBuilder.csAdded EnsureStreamingAssetsInBuild(...) as a safety net copying StreamingAssets/data into the Player folder even if prebuild sync lags.Hardened DataSync invoker to find the sync type whether compiled under Gameplay.Editor or Assembly-CSharp-Editor.